### PR TITLE
Fix star field not restoring after Earth view

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -790,12 +790,21 @@ function setupViewControls() {
             
             // 重置相机位置（确保相机不在太阳内部）
             resetCameraControls();
-            
+
             // 恢复地球可见性
             if (planets['earth'] && planets['earth'].mesh) {
                 planets['earth'].mesh.visible = true;
             }
-            
+
+            // 确保星空重新可见并重新添加到场景（防止被意外移除）
+            if (!starField) {
+                starField = createStars();
+            }
+            if (scene.getObjectByName('starField') === undefined) {
+                scene.add(starField);
+            }
+            starField.visible = true;
+
             // 重置交互标志，以便视角能够自动更新
             controls.hasInteracted = false;
         }


### PR DESCRIPTION
## Summary
- handle missing starField on return to Sun view by recreating and re-adding

## Testing
- `python3 validate_html.py`
